### PR TITLE
scanFiles no longer throws an exception if the directory doesn't exist (PLAT-567)

### DIFF
--- a/utils/file_functions.cc
+++ b/utils/file_functions.cc
@@ -268,8 +268,11 @@ void scanFiles(const std::string & path,
 
     scanFilesThreadData = 0;
 
-    if (res == -1)
+    if (res == -1) {
+        if (errno == ENOENT)
+            return;
         throw ML::Exception(errno, "ftw");
+    }
 }
 
 /** Call fdatasync on the file. */


### PR DESCRIPTION
Since the common use-case is that we want to check if there are any files under a path, not check that the path exists, we make the default to not throw.
