### PR TITLE
Allow turning off boost erf (which crashes valgrind) (PLAT-568)

### DIFF
--- a/algebra/irls.cc
+++ b/algebra/irls.cc
@@ -22,8 +22,12 @@
 
 using namespace std;
 
+#ifndef UNDER_VALGRIND
+#define UNDER_VALGRIND 0
+#endif
+
 // TODO:in which boost version was this added?
-#if (BOOST_VERSION > 103500)
+#if (BOOST_VERSION > 103500 && !UNDER_VALGRIND)
 #include <boost/math/special_functions/erf.hpp>
 
 


### PR DESCRIPTION
This allows you to compile with UNDER_VALGRIND=1 defined, which will avoid
the problematic code (note that it also stops IRLS from working, so it's
only a small workaround).

Has no impact unless enabled.
