### PR TITLE
PLAT-605: make use of "localtime_r" rather than "localtime", which is no...

### DIFF
--- a/arch/exception_handler.cc
+++ b/arch/exception_handler.cc
@@ -125,8 +125,8 @@ void trace_exception(void * object, const std::type_info * tinfo)
     time(&now);
 
     struct tm lt_tm;
-    strftime(datetime, sizeof(datetime), "%FT%H:%M:%S",
-             localtime_r(&now, &lt_tm));
+    strftime(datetime, sizeof(datetime), "%FT%H:%M:%SZ",
+             gmtime_r(&now, &lt_tm));
 
     const char * demangled;
     char * heapDemangled;


### PR DESCRIPTION
...t thread safe and can cause deadlocks within the libc
